### PR TITLE
Fix "Other" link as currently has incorrect anchor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [E-Commerce](#e-commerce)
 - [Search](#search)
 - [Analytics](#analytics)
-- [Other](#other-embeddable-content)
+- [Other](#other)
 - [Related Lists](#related-lists)
 
 ---


### PR DESCRIPTION
The "other" link has an incorrect anchor. Currently goes to `#other-embeddable-content` and should go to `#other`.