### PR TITLE
Add Hulipaa search engine

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -233,6 +233,7 @@ Self-hosted:
 - [fuzzy](https://github.com/mattyork/fuzzy) - Fuzzy search / filter for browser and node
 - [fullproof](https://reyesr.github.io/fullproof/) - Javascript library that provides high-quality full-text search in the browser
 - [Jets.js](https://jets.js.org/) - Native CSS search engine
+- [Hulipaa](https://github.com/sambuccid/hulipaa) - Static full-text search engine capable of handling thousands of pages with a minimalist searchbar UI to add to your static website.
 
 Third party integration:
 


### PR DESCRIPTION
Add Hulipaa in the search section, a static full-text search engine capable of handling thousands of pages.

[Github page](https://github.com/sambuccid/hulipaa)